### PR TITLE
Move parseUnit into repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "bugs": {
     "url": "https://github.com/KyleAMathews/convert-css-length/issues"
   },
-  "dependencies": {
-    "console-polyfill": "^0.1.2",
-    "parse-unit": "^1.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "chai": "^1.10.0",
     "coffee-script": "^1.9.0",
@@ -38,7 +35,7 @@
     "url": "https://github.com/KyleAMathews/convert-css-length.git"
   },
   "scripts": {
-    "test": "mocha -r esm test/index.js",
+    "test": "mocha -r esm test/*.js",
     "build": "microbundle",
     "format": "prettier --write src/index.js"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,15 +7,13 @@
 // Ported from Compass
 // https://github.com/Compass/compass/blob/master/core/stylesheets/compass/typography/_units.scss
 
-import parseUnit from "parse-unit"
+// Emulate the sass function "unit"
+import unit from "./unit"
 
 const baseFontSize = "16px"
 
-// Emulate the sass function "unit"
-const unit = length => parseUnit(length)[1]
-
 // Emulate the sass function "unitless"
-const unitLess = length => parseUnit(length)[0]
+const unitLess = length => parseFloat(length)
 
 // Convert any CSS <length> or <percentage> value to any another.
 //

--- a/src/unit.js
+++ b/src/unit.js
@@ -1,0 +1,3 @@
+export default function unit(input) {
+  return String(input).match(/[\d.\-\+]*\s*(.*)/)[1] || ""
+}

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,0 +1,14 @@
+import { expect } from "chai"
+import unit from "../src/unit.js"
+
+describe("unit", function() {
+  it("should parse unit strings", function() {
+    // does not yet support hex or E notation
+    expect(unit("20px")).to.equal("px")
+    expect(unit("20 gold")).to.equal("gold")
+    expect(unit("2.5 px")).to.equal("px")
+    expect(unit("2.5 %")).to.equal("%")
+    expect(unit("-2.5")).to.equal("")
+    expect(unit("0%%")).to.equal("%%")
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,10 +641,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-console-polyfill@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.1.2.tgz#96cfed51caf78189f699572e6f18271dc37c0e30"
-
 convert-source-map@^1.1.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
@@ -1996,10 +1992,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-unit@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-unit/-/parse-unit-1.0.1.tgz#7e1bb6d5bef3874c28e392526a2541170291eecf"
 
 path-parse@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Original repo didn't have any changes for five years. Probably author
is not interested in it anymore.
https://github.com/mattdesl/parse-unit/pull/1

I suggest to move it into this repository to fully support esm for this
package.

Also removed console-polyfill dependency as not used.